### PR TITLE
feat: add authentication and subscription flows

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,6 +40,20 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="subscriptions"
+        options={{
+          title: 'Plans',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="cart.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="redeem"
+        options={{
+          title: 'Redeem',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="qrcode" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/redeem.tsx
+++ b/app/(tabs)/redeem.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { RedemptionFacade } from '@/facades/RedemptionFacade';
+
+const facade = new RedemptionFacade();
+
+export default function Redeem() {
+  const [code, setCode] = useState('');
+
+  const handleRedeem = async () => {
+    await facade.redeem(code);
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Enter code"
+        value={code}
+        onChangeText={setCode}
+        style={styles.input}
+      />
+      <Button title="Redeem" onPress={handleRedeem} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  input: { borderWidth: 1, borderColor: '#ccc', marginBottom: 12, padding: 8 },
+});

--- a/app/(tabs)/subscriptions.tsx
+++ b/app/(tabs)/subscriptions.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { SubscriptionFacade } from '@/facades/SubscriptionFacade';
+import { Plan } from '@/factories/PlanFactory';
+
+const facade = new SubscriptionFacade();
+
+export default function Subscriptions() {
+  const [plans, setPlans] = useState<Plan[]>([]);
+
+  useEffect(() => {
+    facade.getPlans().then(setPlans);
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      {plans.map((plan) => (
+        <View key={plan.id} style={styles.plan}>
+          <Text>{`${plan.name} - $${plan.price}`}</Text>
+          <Button
+            title="Buy"
+            onPress={() => facade.purchase(plan.id as 'basic' | 'premium', '1')}
+          />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  plan: { marginBottom: 12 },
+});

--- a/app/sign-in.tsx
+++ b/app/sign-in.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { AuthFacade } from '@/facades/AuthFacade';
+
+const auth = new AuthFacade();
+
+export default function SignIn() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSignIn = async () => {
+    await auth.signIn({ username, password });
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Username"
+        value={username}
+        onChangeText={setUsername}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <Button title="Sign In" onPress={handleSignIn} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  input: { borderWidth: 1, borderColor: '#ccc', marginBottom: 12, padding: 8 },
+});

--- a/app/sign-out.tsx
+++ b/app/sign-out.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Button, StyleSheet } from 'react-native';
+import { AuthFacade } from '@/facades/AuthFacade';
+
+const auth = new AuthFacade();
+
+export default function SignOut() {
+  const handleSignOut = async () => {
+    await auth.signOut();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Button title="Sign Out" onPress={handleSignOut} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+});

--- a/app/sign-up.tsx
+++ b/app/sign-up.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { AuthFacade } from '@/facades/AuthFacade';
+
+const auth = new AuthFacade();
+
+export default function SignUp() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSignUp = async () => {
+    await auth.signUp({ username, password });
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Username"
+        value={username}
+        onChangeText={setUsername}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <Button title="Sign Up" onPress={handleSignUp} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  input: { borderWidth: 1, borderColor: '#ccc', marginBottom: 12, padding: 8 },
+});

--- a/facades/AuthFacade.ts
+++ b/facades/AuthFacade.ts
@@ -1,0 +1,21 @@
+import { AuthProxy } from '@/services/auth/AuthProxy';
+import { Credentials, User } from '@/services/auth/AuthService';
+
+/**
+ * Facade exposing simple authentication operations to the UI layer.
+ */
+export class AuthFacade {
+  constructor(private proxy: AuthProxy = new AuthProxy()) {}
+
+  signIn(credentials: Credentials): Promise<User> {
+    return this.proxy.signIn(credentials);
+  }
+
+  signUp(credentials: Credentials): Promise<User> {
+    return this.proxy.signUp(credentials);
+  }
+
+  signOut(): Promise<void> {
+    return this.proxy.signOut();
+  }
+}

--- a/facades/RedemptionFacade.ts
+++ b/facades/RedemptionFacade.ts
@@ -1,0 +1,12 @@
+import { RedemptionProxy } from '@/services/redemption/RedemptionProxy';
+
+/**
+ * Facade exposing a simple redeem method for the UI layer.
+ */
+export class RedemptionFacade {
+  constructor(private proxy: RedemptionProxy = new RedemptionProxy()) {}
+
+  redeem(code: string): Promise<boolean> {
+    return this.proxy.redeem(code);
+  }
+}

--- a/facades/SubscriptionFacade.ts
+++ b/facades/SubscriptionFacade.ts
@@ -1,0 +1,18 @@
+import { PlanFactory, Plan } from '@/factories/PlanFactory';
+import { PlanService } from '@/services/subscription/PlanService';
+
+/**
+ * Facade for subscription related flows such as listing plans and purchasing.
+ */
+export class SubscriptionFacade {
+  constructor(private service: PlanService = new PlanService()) {}
+
+  async getPlans(): Promise<Plan[]> {
+    return this.service.fetchPlans();
+  }
+
+  async purchase(planType: 'basic' | 'premium', userId: string): Promise<void> {
+    const plan: Plan = PlanFactory.create(planType);
+    await this.service.purchasePlan(plan.id, userId);
+  }
+}

--- a/factories/AppFactory.ts
+++ b/factories/AppFactory.ts
@@ -1,0 +1,34 @@
+import { AuthFacade } from '@/facades/AuthFacade';
+import { SubscriptionFacade } from '@/facades/SubscriptionFacade';
+import { RedemptionFacade } from '@/facades/RedemptionFacade';
+
+export interface AppFactory {
+  createAuthFacade(): AuthFacade;
+  createSubscriptionFacade(): SubscriptionFacade;
+  createRedemptionFacade(): RedemptionFacade;
+}
+
+export class UserAppFactory implements AppFactory {
+  createAuthFacade(): AuthFacade {
+    return new AuthFacade();
+  }
+  createSubscriptionFacade(): SubscriptionFacade {
+    return new SubscriptionFacade();
+  }
+  createRedemptionFacade(): RedemptionFacade {
+    return new RedemptionFacade();
+  }
+}
+
+export class StaffAppFactory implements AppFactory {
+  createAuthFacade(): AuthFacade {
+    return new AuthFacade();
+  }
+  createSubscriptionFacade(): SubscriptionFacade {
+    // Staff app might not use subscriptions
+    return new SubscriptionFacade();
+  }
+  createRedemptionFacade(): RedemptionFacade {
+    return new RedemptionFacade();
+  }
+}

--- a/factories/PlanFactory.ts
+++ b/factories/PlanFactory.ts
@@ -1,0 +1,34 @@
+export interface Plan {
+  id: string;
+  name: string;
+  price: number;
+  totalCups: number;
+}
+
+class BasicPlan implements Plan {
+  id = 'basic';
+  name = 'Basic Plan';
+  price = 10;
+  totalCups = 10;
+}
+
+class PremiumPlan implements Plan {
+  id = 'premium';
+  name = 'Premium Plan';
+  price = 20;
+  totalCups = 25;
+}
+
+/**
+ * Factory responsible for creating plan objects based on type.
+ */
+export class PlanFactory {
+  static create(type: 'basic' | 'premium'): Plan {
+    switch (type) {
+      case 'premium':
+        return new PremiumPlan();
+      default:
+        return new BasicPlan();
+    }
+  }
+}

--- a/services/auth/AuthProxy.ts
+++ b/services/auth/AuthProxy.ts
@@ -1,0 +1,25 @@
+import { AuthService, Credentials, User } from './AuthService';
+
+/**
+ * Proxy that can be used to attach headers, tokens or logging
+ * before delegating calls to the underlying AuthService.
+ */
+export class AuthProxy {
+  constructor(private service: AuthService = new AuthService()) {}
+
+  async signIn(credentials: Credentials): Promise<User> {
+    // Example: add logging
+    console.log('AuthProxy: signIn called');
+    return this.service.signIn(credentials);
+  }
+
+  async signUp(credentials: Credentials): Promise<User> {
+    console.log('AuthProxy: signUp called');
+    return this.service.signUp(credentials);
+  }
+
+  async signOut(): Promise<void> {
+    console.log('AuthProxy: signOut called');
+    return this.service.signOut();
+  }
+}

--- a/services/auth/AuthService.ts
+++ b/services/auth/AuthService.ts
@@ -1,0 +1,31 @@
+export interface Credentials {
+  username: string;
+  password: string;
+}
+
+export interface User {
+  id: string;
+  username: string;
+}
+
+/**
+ * AuthService is responsible for communicating with the backend API.
+ * In a real application these methods would use `fetch` or another
+ * networking library. Here we simply mock the behaviour.
+ */
+export class AuthService {
+  async signIn({ username, password }: Credentials): Promise<User> {
+    // mock sign in
+    return { id: '1', username };
+  }
+
+  async signUp({ username, password }: Credentials): Promise<User> {
+    // mock sign up
+    return { id: '1', username };
+  }
+
+  async signOut(): Promise<void> {
+    // mock sign out
+    return;
+  }
+}

--- a/services/redemption/RedemptionProxy.ts
+++ b/services/redemption/RedemptionProxy.ts
@@ -1,0 +1,14 @@
+import { RedemptionService } from './RedemptionService';
+
+/**
+ * Proxy adding an abstraction layer over RedemptionService, allowing
+ * logging or authentication headers in real implementations.
+ */
+export class RedemptionProxy {
+  constructor(private service: RedemptionService = new RedemptionService()) {}
+
+  async redeem(code: string): Promise<boolean> {
+    console.log('RedemptionProxy: redeem called');
+    return this.service.redeem(code);
+  }
+}

--- a/services/redemption/RedemptionService.ts
+++ b/services/redemption/RedemptionService.ts
@@ -1,0 +1,10 @@
+/**
+ * Service handling coffee ticket redemption. Would typically reach out to
+ * backend to validate QR codes and update tracking information.
+ */
+export class RedemptionService {
+  async redeem(code: string): Promise<boolean> {
+    console.log(`Redeeming code: ${code}`);
+    return true; // mock success
+  }
+}

--- a/services/subscription/PlanService.ts
+++ b/services/subscription/PlanService.ts
@@ -1,0 +1,19 @@
+import { Plan } from '@/factories/PlanFactory';
+
+/**
+ * Service that would normally fetch plans from API and manage purchases.
+ */
+export class PlanService {
+  async fetchPlans(): Promise<Plan[]> {
+    // mock plan list
+    return [
+      { id: 'basic', name: 'Basic Plan', price: 10, totalCups: 10 },
+      { id: 'premium', name: 'Premium Plan', price: 20, totalCups: 25 },
+    ];
+  }
+
+  async purchasePlan(planId: string, userId: string): Promise<void> {
+    console.log(`Purchasing plan ${planId} for user ${userId}`);
+    return;
+  }
+}


### PR DESCRIPTION
## Summary
- add auth, subscription, and redemption facades with corresponding proxies and services
- expose plan factory and abstract app factory for user and staff flows
- provide basic screens and tab navigation for sign in, plan browsing, and redemption

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1a856451483288f9aa3f0902aebcd