### PR TITLE
Add search tab and logout support

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -42,6 +42,13 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="search"
+        options={{
+          title: 'Search',
+          tabBarIcon: () => <MaterialIcons name="search" size={24} color="black" />,
+        }}
+      />
+      <Tabs.Screen
         name="subscriptions"
         options={{
           title: 'Subscription',

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -13,13 +13,16 @@ const auth = new AuthFacade();
 
 export default function Profile() {
   const router = useRouter();
-  const { token, email } = useAuth();
+  const { token, email, signOut } = useAuth();
   const colorScheme = useColorScheme();
   const toggleScheme = useToggleColorScheme();
   const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
-    if (!token) return;
+    if (!token) {
+      setUser(null);
+      return;
+    }
     auth
       .currentUser(token)
       .then(setUser)
@@ -60,9 +63,13 @@ export default function Profile() {
       ) : (
         email && <Text style={styles.info}>{email}</Text>
       )}
-      {!token && (
+      {!token ? (
         <Button mode="contained" onPress={handleSignIn} style={styles.signInButton}>
           Sign In
+        </Button>
+      ) : (
+        <Button mode="outlined" onPress={signOut} style={styles.signOutButton}>
+          Sign Out
         </Button>
       )}
     </ThemedView>
@@ -74,4 +81,5 @@ const styles = StyleSheet.create({
   info: { marginBottom: 8, padding: 16 },
   card: { margin: 16 },
   signInButton: { marginHorizontal: 16, marginTop: 8 },
+  signOutButton: { marginHorizontal: 16, marginTop: 8 },
 });

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Chip, Searchbar, Text } from 'react-native-paper';
+
+import { ThemedView } from '@/components/ThemedView';
+
+const FILTERS = ['All', 'Coffee', 'Tea', 'Juice'];
+
+export default function Search() {
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState('All');
+
+  return (
+    <ThemedView style={styles.container}>
+      <Searchbar
+        placeholder="Search drinks"
+        value={query}
+        onChangeText={setQuery}
+        style={styles.search}
+      />
+      <View style={styles.filters}>
+        {FILTERS.map((f) => (
+          <Chip
+            key={f}
+            style={styles.chip}
+            selected={selected === f}
+            onPress={() => setSelected(f)}
+          >
+            {f}
+          </Chip>
+        ))}
+      </View>
+      <View style={styles.placeholder}>
+        <Text>Search results will appear here.</Text>
+      </View>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  search: { marginBottom: 12 },
+  filters: { flexDirection: 'row', marginBottom: 16 },
+  chip: { marginRight: 8 },
+  placeholder: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+});


### PR DESCRIPTION
## Summary
- add search screen with basic layout and filter chips
- support signing out by extending auth hook and profile UI
- include search tab in bottom navigation

## Testing
- `npm test` (Missing script "test")
- `npm run lint` (expo not found)


------
https://chatgpt.com/codex/tasks/task_e_68a97566175c832891de3b0825e12e40