### PR TITLE
Add search tab, logout support, and ticket-based UI

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -38,21 +38,21 @@ export default function TabLayout() {
         name="profile"
         options={{
           title: 'Profile',
-          tabBarIcon: () => <MaterialIcons name="person" size={24} color="black" />,
+          tabBarIcon: ({ color }) => <MaterialIcons name="person" size={24} color={color} />,
         }}
       />
       <Tabs.Screen
         name="search"
         options={{
           title: 'Search',
-          tabBarIcon: () => <MaterialIcons name="search" size={24} color="black" />,
+          tabBarIcon: ({ color }) => <MaterialIcons name="search" size={24} color={color} />,
         }}
       />
       <Tabs.Screen
         name="subscriptions"
         options={{
           title: 'Subscription',
-          tabBarIcon: () => <MaterialIcons name="attach-money" size={24} color="black" />,
+          tabBarIcon: ({ color }) => <MaterialIcons name="attach-money" size={24} color={color} />,
         }}
       />
     </Tabs>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -42,6 +42,13 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="search"
+        options={{
+          title: 'Search',
+          tabBarIcon: () => <MaterialIcons name="search" size={24} color="black" />,
+        }}
+      />
+      <Tabs.Screen
         name="subscriptions"
         options={{
           title: 'Subscription',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -50,39 +50,42 @@ export default function Home() {
 
   if (loading) {
     return (
-      <ThemedView style={styles.center}>
+      <ThemedView style={styles.center} useSafeArea>
         <ActivityIndicator />
       </ThemedView>
     );
   }
 
   return (
-    <FlatList
-      contentContainerStyle={styles.container}
-      data={categories}
-      ListHeaderComponent={
-        <Text style={styles.remaining}>
-          Remaining Tickets: {remaining ?? '—'}
-        </Text>
-      }
-      keyExtractor={(item) => item.title}
-      renderItem={({ item }) => (
-        <View style={styles.category}>
-          <List.Subheader style={styles.sectionTitle}>{item.title}</List.Subheader>
-          <FlatList
-            data={item.data}
-            horizontal
-            keyExtractor={(c) => c.coffeeId.toString()}
-            renderItem={({ item: coffee }) => <CoffeeItemCard item={coffee} />}
-            showsHorizontalScrollIndicator={false}
-          />
-        </View>
-      )}
-    />
+    <ThemedView style={styles.screen} useSafeArea>
+      <FlatList
+        contentContainerStyle={styles.container}
+        data={categories}
+        ListHeaderComponent={
+          <Text style={styles.remaining}>
+            Remaining Tickets: {remaining ?? '—'}
+          </Text>
+        }
+        keyExtractor={(item) => item.title}
+        renderItem={({ item }) => (
+          <View style={styles.category}>
+            <List.Subheader style={styles.sectionTitle}>{item.title}</List.Subheader>
+            <FlatList
+              data={item.data}
+              horizontal
+              keyExtractor={(c) => c.coffeeId.toString()}
+              renderItem={({ item: coffee }) => <CoffeeItemCard item={coffee} />}
+              showsHorizontalScrollIndicator={false}
+            />
+          </View>
+        )}
+      />
+    </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
+  screen: { flex: 1 },
   container: { padding: 16 },
   center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   remaining: { marginBottom: 16, fontWeight: 'bold' },

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -58,14 +58,10 @@ export default function Home() {
 
   return (
     <ThemedView style={styles.screen} useSafeArea>
+      <Text style={styles.remaining}>Remaining Tickets: {remaining ?? '—'}</Text>
       <FlatList
-        contentContainerStyle={styles.container}
+        contentContainerStyle={styles.list}
         data={categories}
-        ListHeaderComponent={
-          <Text style={styles.remaining}>
-            Remaining Tickets: {remaining ?? '—'}
-          </Text>
-        }
         keyExtractor={(item) => item.title}
         renderItem={({ item }) => (
           <View style={styles.category}>
@@ -86,9 +82,9 @@ export default function Home() {
 
 const styles = StyleSheet.create({
   screen: { flex: 1 },
-  container: { padding: 16 },
+  list: { paddingHorizontal: 16, paddingBottom: 16 },
   center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  remaining: { marginBottom: 16, fontWeight: 'bold' },
+  remaining: { marginHorizontal: 16, marginBottom: 16, fontWeight: 'bold' },
   sectionTitle: { marginBottom: 8 },
   category: { marginBottom: 24 },
 });

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -38,11 +38,11 @@ export default function Profile() {
       <Appbar.Header>
         <Appbar.Content title="Profile" />
         <Appbar.Action
-          icon={() => (
+          icon={({ size, color }) => (
             <MaterialIcons
               name={colorScheme === 'dark' ? 'light-mode' : 'dark-mode'}
-              size={24}
-              color="black"
+              size={size}
+              color={color}
             />
           )}
           onPress={toggleScheme}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -34,7 +34,7 @@ export default function Profile() {
   };
 
   return (
-    <ThemedView style={styles.container}>
+    <ThemedView style={styles.container} useSafeArea>
       <Appbar.Header>
         <Appbar.Content title="Profile" />
         <Appbar.Action

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -13,13 +13,16 @@ const auth = new AuthFacade();
 
 export default function Profile() {
   const router = useRouter();
-  const { token, email } = useAuth();
+  const { token, email, signOut } = useAuth();
   const colorScheme = useColorScheme();
   const toggleScheme = useToggleColorScheme();
   const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
-    if (!token) return;
+    if (!token) {
+      setUser(null);
+      return;
+    }
     auth
       .currentUser(token)
       .then(setUser)
@@ -60,9 +63,13 @@ export default function Profile() {
       ) : (
         email && <Text style={styles.info}>{email}</Text>
       )}
-      {!token && (
+      {!token ? (
         <Button mode="contained" onPress={handleSignIn} style={styles.signInButton}>
           Sign In
+        </Button>
+      ) : (
+        <Button mode="outlined" onPress={signOut} style={styles.signOutButton}>
+          Sign Out
         </Button>
       )}
     </ThemedView>
@@ -74,4 +81,5 @@ const styles = StyleSheet.create({
   info: { marginBottom: 8, padding: 16 },
   card: { margin: 16 },
   signInButton: { marginHorizontal: 16, marginTop: 8 },
+  signOutButton: { marginHorizontal: 16, marginTop: 8 },
 });

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Chip, Searchbar, Text } from 'react-native-paper';
+
+import { ThemedView } from '@/components/ThemedView';
+
+const FILTERS = ['All', 'Coffee', 'Tea', 'Juice'];
+
+export default function Search() {
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState('All');
+
+  return (
+    <ThemedView style={styles.container}>
+      <Searchbar
+        placeholder="Search drinks"
+        value={query}
+        onChangeText={setQuery}
+        style={styles.search}
+      />
+      <View style={styles.filters}>
+        {FILTERS.map((f) => (
+          <Chip
+            key={f}
+            style={styles.chip}
+            selected={selected === f}
+            onPress={() => setSelected(f)}
+          >
+            {f}
+          </Chip>
+        ))}
+      </View>
+      <View style={styles.placeholder}>
+        <Text>Search results will appear here.</Text>
+      </View>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  search: { marginBottom: 12 },
+  filters: { flexDirection: 'row', marginBottom: 16 },
+  chip: { marginRight: 8 },
+  placeholder: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+});

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -11,7 +11,7 @@ export default function Search() {
   const [selected, setSelected] = useState('All');
 
   return (
-    <ThemedView style={styles.container}>
+    <ThemedView style={styles.container} useSafeArea>
       <Searchbar
         placeholder="Search drinks"
         value={query}

--- a/app/(tabs)/subscriptions.tsx
+++ b/app/(tabs)/subscriptions.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { FlatList, StyleSheet } from 'react-native';
 import { Card, Text } from 'react-native-paper';
+import { ThemedView } from '@/components/ThemedView';
 import { useRouter } from 'expo-router';
 
 import { SubscriptionFacade } from '@/facades/SubscriptionFacade';
@@ -17,24 +18,27 @@ export default function Subscriptions() {
   }, []);
 
   return (
-    <FlatList
-      contentContainerStyle={styles.container}
-      data={plans}
-      keyExtractor={(item) => item.planId.toString()}
-      renderItem={({ item }) => (
-        <Card style={styles.card} onPress={() => router.push(`/plan/${item.planId}`)}>
-          <Card.Title title={item.planName} />
-          <Card.Content>
-            <Text>{item.description}</Text>
-            <Text style={styles.price}>{`${item.price}₫`}</Text>
-          </Card.Content>
-        </Card>
-      )}
-    />
+    <ThemedView style={styles.screen} useSafeArea>
+      <FlatList
+        contentContainerStyle={styles.container}
+        data={plans}
+        keyExtractor={(item) => item.planId.toString()}
+        renderItem={({ item }) => (
+          <Card style={styles.card} onPress={() => router.push(`/plan/${item.planId}`)}>
+            <Card.Title title={item.planName} />
+            <Card.Content>
+              <Text>{item.description}</Text>
+              <Text style={styles.price}>{`${item.price}₫`}</Text>
+            </Card.Content>
+          </Card>
+        )}
+      />
+    </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
+  screen: { flex: 1 },
   container: { padding: 16 },
   card: { marginBottom: 12 },
   price: { marginTop: 8, fontWeight: 'bold' },

--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -8,7 +8,7 @@ export default function NotFoundScreen() {
   return (
     <>
       <Stack.Screen options={{ title: 'Oops!' }} />
-      <ThemedView style={styles.container}>
+      <ThemedView style={styles.container} useSafeArea>
         <ThemedText type="title">This screen does not exist.</ThemedText>
         <Link href="/" style={styles.link}>
           <ThemedText type="link">Go to home screen!</ThemedText>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,8 +6,8 @@ import 'react-native-reanimated';
 
 import { AuthProvider } from '@/hooks/useAuth';
 import { ColorSchemeProvider, useColorScheme } from '@/hooks/useColorScheme';
-
-import { Provider as PaperProvider } from 'react-native-paper';
+import { Provider as PaperProvider, MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
+import { Colors } from '@/constants/Colors';
 
 export default function RootLayout() {
   const [loaded] = useFonts({
@@ -28,11 +28,60 @@ export default function RootLayout() {
 
 function RootNavigation() {
   const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const navigationTheme = isDark
+    ? {
+        ...DarkTheme,
+        colors: {
+          ...DarkTheme.colors,
+          background: Colors.dark.background,
+          card: Colors.dark.card,
+          primary: Colors.dark.tint,
+          text: Colors.dark.text,
+          border: Colors.dark.icon,
+        },
+      }
+    : {
+        ...DefaultTheme,
+        colors: {
+          ...DefaultTheme.colors,
+          background: Colors.light.background,
+          card: Colors.light.card,
+          primary: Colors.light.tint,
+          text: Colors.light.text,
+          border: Colors.light.icon,
+        },
+      };
+
+  const paperTheme = isDark
+    ? {
+        ...MD3DarkTheme,
+        colors: {
+          ...MD3DarkTheme.colors,
+          background: Colors.dark.background,
+          surface: Colors.dark.card,
+          primary: Colors.dark.tint,
+          onPrimary: Colors.dark.text,
+          onSurface: Colors.dark.text,
+        },
+      }
+    : {
+        ...MD3LightTheme,
+        colors: {
+          ...MD3LightTheme.colors,
+          background: Colors.light.background,
+          surface: Colors.light.card,
+          primary: Colors.light.tint,
+          onPrimary: Colors.light.text,
+          onSurface: Colors.light.text,
+        },
+      };
 
   return (
     <AuthProvider>
-      <PaperProvider>
-        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <PaperProvider theme={paperTheme}>
+        <ThemeProvider value={navigationTheme}>
           <Stack>
             <Stack.Screen name="index" options={{ headerShown: false }} />
             <Stack.Screen name="sign-in" options={{ title: 'Sign In' }} />

--- a/app/coffee/[id].tsx
+++ b/app/coffee/[id].tsx
@@ -40,7 +40,7 @@ export default function CoffeeDetail() {
 
   if (loading) {
     return (
-      <ThemedView style={styles.center}>
+      <ThemedView style={styles.center} useSafeArea>
         <ActivityIndicator />
       </ThemedView>
     );
@@ -48,7 +48,7 @@ export default function CoffeeDetail() {
 
   if (!item) {
     return (
-      <ThemedView style={styles.center}>
+      <ThemedView style={styles.center} useSafeArea>
         <Text>No coffee found</Text>
       </ThemedView>
     );
@@ -57,7 +57,7 @@ export default function CoffeeDetail() {
   const secondary = useThemeColor({}, 'icon');
 
   return (
-    <ThemedView style={{ flex: 1 }}>
+    <ThemedView style={{ flex: 1 }} useSafeArea>
       <ScrollView contentContainerStyle={styles.container}>
         {item.imageUrl ? <Image source={{ uri: item.imageUrl }} style={styles.image} /> : null}
         <Text variant="headlineSmall" style={styles.title}>

--- a/app/coffee/[id].tsx
+++ b/app/coffee/[id].tsx
@@ -15,6 +15,7 @@ export default function CoffeeDetail() {
   const [loading, setLoading] = useState(true);
   const [remaining, setRemaining] = useState<number | null>(null);
   const { token } = useAuth();
+  const secondary = useThemeColor({}, 'icon');
 
   useEffect(() => {
     if (!id) return;
@@ -53,8 +54,6 @@ export default function CoffeeDetail() {
       </ThemedView>
     );
   }
-
-  const secondary = useThemeColor({}, 'icon');
 
   return (
     <ThemedView style={{ flex: 1 }} useSafeArea>

--- a/app/coffee/[id].tsx
+++ b/app/coffee/[id].tsx
@@ -7,6 +7,7 @@ import { ThemedView } from '@/components/ThemedView';
 import { CoffeeItem, CoffeeItemService } from '@/services/coffee/CoffeeItemService';
 import { AuthFacade } from '@/facades/AuthFacade';
 import { useAuth } from '@/hooks/useAuth';
+import { useThemeColor } from '@/hooks/useThemeColor';
 
 export default function CoffeeDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -53,6 +54,8 @@ export default function CoffeeDetail() {
     );
   }
 
+  const secondary = useThemeColor({}, 'icon');
+
   return (
     <ThemedView style={{ flex: 1 }}>
       <ScrollView contentContainerStyle={styles.container}>
@@ -61,13 +64,9 @@ export default function CoffeeDetail() {
           {item.coffeeName}
         </Text>
         <Text style={styles.description}>{item.description}</Text>
-        <Text style={styles.code}>Code: {item.code}</Text>
+        <Text style={[styles.code, { color: secondary }]}>Code: {item.code}</Text>
         <Text style={styles.remaining}>Tickets left: {remaining ?? '—'}</Text>
-        <Button
-          mode="contained"
-          icon="ticket-outline"
-          style={styles.button}
-        >
+        <Button mode="contained" icon="ticket-outline" style={styles.button}>
           Use Ticket
         </Button>
       </ScrollView>
@@ -81,7 +80,7 @@ const styles = StyleSheet.create({
   image: { width: '100%', height: 200, marginBottom: 16 },
   title: { marginBottom: 8 },
   description: { marginBottom: 8 },
-  code: { marginBottom: 16, color: '#666' },
+  code: { marginBottom: 16 },
   remaining: { marginBottom: 8, fontWeight: 'bold' },
   button: { marginTop: 8 },
 });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,7 +1,8 @@
 
 import React from 'react';
-import { Button, StyleSheet, Pressable } from 'react-native';
+import { StyleSheet, Pressable } from 'react-native';
 import { useRouter } from 'expo-router';
+import { Button } from 'react-native-paper';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 import { useThemeColor } from '@/hooks/useThemeColor';
@@ -12,8 +13,12 @@ export default function Welcome() {
   const tint = useThemeColor({}, 'tint');
   return (
     <ThemedView style={styles.container} useSafeArea>
-      <Button title="Sign In" onPress={() => router.push('/sign-in')} />
-      <Button title="Sign Up" onPress={() => router.push('/sign-up')} />
+      <Button mode="contained" onPress={() => router.push('/sign-in')} style={styles.button}>
+        Sign In
+      </Button>
+      <Button mode="outlined" onPress={() => router.push('/sign-up')} style={styles.button}>
+        Sign Up
+      </Button>
       <Pressable onPress={() => router.replace('/(tabs)')} style={styles.guest}>
         <ThemedText style={[styles.guestText, { color: tint }]}>Try as guest</ThemedText>
       </Pressable>
@@ -23,6 +28,7 @@ export default function Welcome() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 16, gap: 12 },
+  button: { marginVertical: 4 },
   guest: { marginTop: 16 },
   guestText: { textAlign: 'center' },
 });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -6,20 +6,28 @@ import { Button } from 'react-native-paper';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 import { useThemeColor } from '@/hooks/useThemeColor';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function Welcome() {
   const router = useRouter();
+  const { signOut } = useAuth();
 
   const tint = useThemeColor({}, 'tint');
+
+  const handleGuest = async () => {
+    await signOut();
+    router.replace('/(tabs)');
+  };
+
   return (
     <ThemedView style={styles.container} useSafeArea>
-      <Button mode="contained" onPress={() => router.push('/sign-in')} style={styles.button}>
+      <Button mode="contained" onPress={() => router.replace('/sign-in')} style={styles.button}>
         Sign In
       </Button>
-      <Button mode="outlined" onPress={() => router.push('/sign-up')} style={styles.button}>
+      <Button mode="outlined" onPress={() => router.replace('/sign-up')} style={styles.button}>
         Sign Up
       </Button>
-      <Pressable onPress={() => router.replace('/(tabs)')} style={styles.guest}>
+      <Pressable onPress={handleGuest} style={styles.guest}>
         <ThemedText style={[styles.guestText, { color: tint }]}>Try as guest</ThemedText>
       </Pressable>
     </ThemedView>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -11,7 +11,7 @@ export default function Welcome() {
 
   const tint = useThemeColor({}, 'tint');
   return (
-    <ThemedView style={styles.container}>
+    <ThemedView style={styles.container} useSafeArea>
       <Button title="Sign In" onPress={() => router.push('/sign-in')} />
       <Button title="Sign Up" onPress={() => router.push('/sign-up')} />
       <Pressable onPress={() => router.replace('/(tabs)')} style={styles.guest}>

--- a/app/plan/[id].tsx
+++ b/app/plan/[id].tsx
@@ -29,7 +29,7 @@ export default function PlanDetail() {
 
   if (loading) {
     return (
-      <ThemedView style={styles.center}>
+      <ThemedView style={styles.center} useSafeArea>
         <ActivityIndicator />
       </ThemedView>
     );
@@ -37,7 +37,7 @@ export default function PlanDetail() {
 
   if (!plan) {
     return (
-      <ThemedView style={styles.center}>
+      <ThemedView style={styles.center} useSafeArea>
         <Text>No plan found</Text>
       </ThemedView>
     );
@@ -57,7 +57,7 @@ export default function PlanDetail() {
   };
 
   return (
-    <ThemedView style={styles.container}>
+    <ThemedView style={styles.container} useSafeArea>
       <Card>
         <Card.Title title={plan.planName} />
         <Card.Content>

--- a/app/sign-in.tsx
+++ b/app/sign-in.tsx
@@ -29,7 +29,7 @@ export default function SignIn() {
 
   const textColor = useThemeColor({}, 'text');
   return (
-    <ThemedView style={styles.container}>
+    <ThemedView style={styles.container} useSafeArea>
       <TextInput
         label="Email"
         value={email}

--- a/app/sign-up.tsx
+++ b/app/sign-up.tsx
@@ -21,7 +21,7 @@ export default function SignUp() {
 
   const textColor = useThemeColor({}, 'text');
   return (
-    <ThemedView style={styles.container}>
+    <ThemedView style={styles.container} useSafeArea>
       <TextInput
         label="Email"
         value={email}

--- a/app/vnpay.tsx
+++ b/app/vnpay.tsx
@@ -10,14 +10,14 @@ export default function VnpayScreen() {
 
   if (!url) {
     return (
-      <ThemedView style={styles.center}>
+      <ThemedView style={styles.center} useSafeArea>
         <Text>Missing payment URL</Text>
       </ThemedView>
     );
   }
 
   return (
-    <ThemedView style={styles.container}>
+    <ThemedView style={styles.container} useSafeArea>
       <WebView source={{ uri: url }} style={{ flex: 1 }} />
     </ThemedView>
   );

--- a/components/CoffeeItemCard.tsx
+++ b/components/CoffeeItemCard.tsx
@@ -24,7 +24,12 @@ export function CoffeeItemCard({ item }: Props) {
         >
           {item.coffeeName}
         </Text>
-        <Text variant="bodyMedium" numberOfLines={2} ellipsizeMode="tail">
+        <Text
+          variant="bodyMedium"
+          numberOfLines={2}
+          ellipsizeMode="tail"
+          style={styles.description}
+        >
           {item.description}
         </Text>
       </Card.Content>
@@ -53,5 +58,8 @@ const styles = StyleSheet.create({
   },
   title: {
     marginBottom: 4,
+  },
+  description: {
+    minHeight: 40,
   },
 });

--- a/components/CoffeeItemCard.tsx
+++ b/components/CoffeeItemCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
-import { Card, Text } from 'react-native-paper';
+import { Card, Text, Button } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 import type { CoffeeItem } from '@/services/coffee/CoffeeItemService';
 
@@ -19,8 +19,20 @@ export function CoffeeItemCard({ item }: Props) {
         <Text variant="titleMedium" style={styles.title}>
           {item.coffeeName}
         </Text>
-        <Text variant="bodyMedium">{item.description}</Text>
+        <Text variant="bodyMedium" numberOfLines={2}>
+          {item.description}
+        </Text>
       </Card.Content>
+      <Card.Actions>
+        <Button
+          icon="ticket-outline"
+          mode="contained"
+          compact
+          onPress={handlePress}
+        >
+          Use Ticket
+        </Button>
+      </Card.Actions>
     </Card>
   );
 }

--- a/components/CoffeeItemCard.tsx
+++ b/components/CoffeeItemCard.tsx
@@ -16,7 +16,12 @@ export function CoffeeItemCard({ item }: Props) {
     <Card style={styles.card} onPress={handlePress}>
       {item.imageUrl ? <Card.Cover source={{ uri: item.imageUrl }} style={styles.cover} /> : null}
       <Card.Content>
-        <Text variant="titleMedium" style={styles.title}>
+        <Text
+          variant="titleMedium"
+          style={styles.title}
+          numberOfLines={2}
+          ellipsizeMode="tail"
+        >
           {item.coffeeName}
         </Text>
         <Text variant="bodyMedium" numberOfLines={2}>

--- a/components/CoffeeItemCard.tsx
+++ b/components/CoffeeItemCard.tsx
@@ -24,7 +24,7 @@ export function CoffeeItemCard({ item }: Props) {
         >
           {item.coffeeName}
         </Text>
-        <Text variant="bodyMedium" numberOfLines={2}>
+        <Text variant="bodyMedium" numberOfLines={2} ellipsizeMode="tail">
           {item.description}
         </Text>
       </Card.Content>

--- a/components/ThemedView.tsx
+++ b/components/ThemedView.tsx
@@ -1,14 +1,24 @@
 import { View, type ViewProps } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useThemeColor } from '@/hooks/useThemeColor';
 
 export type ThemedViewProps = ViewProps & {
   lightColor?: string;
   darkColor?: string;
+  useSafeArea?: boolean;
 };
 
-export function ThemedView({ style, lightColor, darkColor, ...otherProps }: ThemedViewProps) {
+export function ThemedView({
+  style,
+  lightColor,
+  darkColor,
+  useSafeArea = false,
+  ...otherProps
+}: ThemedViewProps) {
   const backgroundColor = useThemeColor({ light: lightColor, dark: darkColor }, 'background');
 
-  return <View style={[{ backgroundColor }, style]} {...otherProps} />;
+  const Component = useSafeArea ? SafeAreaView : View;
+
+  return <Component style={[{ backgroundColor }, style]} {...otherProps} />;
 }

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -3,24 +3,23 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
-const tintColorLight = '#0a7ea4';
-const tintColorDark = '#fff';
-
 export const Colors = {
   light: {
-    text: '#11181C',
-    background: '#fff',
-    tint: tintColorLight,
-    icon: '#687076',
-    tabIconDefault: '#687076',
-    tabIconSelected: tintColorLight,
+    text: '#262b32',
+    background: '#d8d1b9',
+    card: '#cec4a7',
+    tint: '#c1b69c',
+    icon: '#a79e8d',
+    tabIconDefault: '#a79e8d',
+    tabIconSelected: '#c1b69c',
   },
   dark: {
-    text: '#ECEDEE',
-    background: '#151718',
-    tint: tintColorDark,
-    icon: '#9BA1A6',
-    tabIconDefault: '#9BA1A6',
-    tabIconSelected: tintColorDark,
+    text: '#c9d1d9',
+    background: '#262b32',
+    card: '#505961',
+    tint: '#b1bac4',
+    icon: '#6e7681',
+    tabIconDefault: '#6e7681',
+    tabIconSelected: '#b1bac4',
   },
 };


### PR DESCRIPTION
## Summary
- add search screen with basic layout and filter chips
- support signing out by extending auth hook and profile UI
- include search tab in bottom navigation
- redesign drink cards and screens to revolve around ticket usage

## Testing
- `npm test` (Missing script "test")
- `npm run lint` (expo: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a97566175c832891de3b0825e12e40