### PR TITLE
Use proxy redirect for Google sign-in

### DIFF
--- a/app/sign-in.tsx
+++ b/app/sign-in.tsx
@@ -1,11 +1,16 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Alert, StyleSheet, View } from 'react-native';
 import { Button, Text, TextInput } from 'react-native-paper';
 import { useRouter } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
+import * as Google from 'expo-auth-session/providers/google';
+import { makeRedirectUri } from 'expo-auth-session';
 import { AuthFacade } from '@/facades/AuthFacade';
 import { useAuth } from '@/hooks/useAuth';
 import { ThemedView } from '@/components/ThemedView';
 import { useThemeColor } from '@/hooks/useThemeColor';
+
+WebBrowser.maybeCompleteAuthSession();
 
 const auth = new AuthFacade();
 
@@ -14,6 +19,22 @@ export default function SignIn() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const { signIn: setAuth } = useAuth();
+
+  const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
+    clientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID ?? '',
+    redirectUri: makeRedirectUri({ useProxy: true }),
+  });
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const { id_token } = response.params;
+      if (id_token) {
+        setAuth(id_token, '');
+        Alert.alert('Success', 'Signed in successfully');
+        router.replace('/(tabs)');
+      }
+    }
+  }, [response, router, setAuth]);
 
   const handleSignIn = async () => {
     try {
@@ -47,6 +68,14 @@ export default function SignIn() {
       />
       <Button mode="contained" onPress={handleSignIn} style={styles.button}>
         Sign In
+      </Button>
+      <Button
+        mode="outlined"
+        disabled={!request}
+        onPress={() => promptAsync({ useProxy: true })}
+        style={styles.button}
+      >
+        Sign In with Google
       </Button>
       <View style={styles.separator}>
         <Text style={[styles.separatorText, { color: textColor }]}>If you don&apos;t have an account</Text>


### PR DESCRIPTION
## Summary
- add Expo Auth Session Google sign-in with proxy redirect handling
- call Google promptAsync using Expo proxy

## Testing
- `npm install` *(fails: 403 Forbidden for @react-native-async-storage/async-storage)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe7083e2883289877e6b116e6d3a3