### PR TITLE
Use custom scheme for Google OAuth

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,6 +37,7 @@
     ],
     "experiments": {
       "typedRoutes": true
-    }
+    },
+    "owner": "genchio"
   }
 }

--- a/app/coffee/[id].tsx
+++ b/app/coffee/[id].tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Image, ScrollView, StyleSheet } from 'react-native';
-import { ActivityIndicator, Button, Text } from 'react-native-paper';
+import { ActivityIndicator, Button, Text, Modal, Portal } from 'react-native-paper';
+import QRCode from 'react-native-qrcode-svg';
 import { useLocalSearchParams } from 'expo-router';
 
 import { ThemedView } from '@/components/ThemedView';
@@ -14,7 +15,9 @@ export default function CoffeeDetail() {
   const [item, setItem] = useState<CoffeeItem | null>(null);
   const [loading, setLoading] = useState(true);
   const [remaining, setRemaining] = useState<number | null>(null);
-  const { token } = useAuth();
+  const [qrValue, setQrValue] = useState<string | null>(null);
+  const [qrVisible, setQrVisible] = useState(false);
+  const { token, userId } = useAuth();
   const secondary = useThemeColor({}, 'icon');
 
   useEffect(() => {
@@ -38,6 +41,23 @@ export default function CoffeeDetail() {
       .then((u) => setRemaining(u.userSubscriptions.remainingCups))
       .catch(console.error);
   }, [token]);
+
+  const handleUseTicket = async () => {
+    if (!token || !userId || !id) return;
+    const svc = new CoffeeItemService();
+    try {
+      const res = await svc.generateQrCode(userId, Number(id), token);
+      const payload = JSON.stringify({
+        subscriptionId: res.subscriptionId,
+        coffeeCode: res.coffeeCode,
+        userId: res.userId,
+      });
+      setQrValue(payload);
+      setQrVisible(true);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 
   if (loading) {
     return (
@@ -65,10 +85,27 @@ export default function CoffeeDetail() {
         <Text style={styles.description}>{item.description}</Text>
         <Text style={[styles.code, { color: secondary }]}>Code: {item.code}</Text>
         <Text style={styles.remaining}>Tickets left: {remaining ?? '—'}</Text>
-        <Button mode="contained" icon="ticket-outline" style={styles.button}>
+        <Button
+          mode="contained"
+          icon="ticket-outline"
+          style={styles.button}
+          onPress={handleUseTicket}
+        >
           Use Ticket
         </Button>
       </ScrollView>
+      <Portal>
+        <Modal
+          visible={qrVisible}
+          onDismiss={() => setQrVisible(false)}
+          contentContainerStyle={styles.modal}
+        >
+          {qrValue ? <QRCode value={qrValue} size={200} /> : null}
+          <Button onPress={() => setQrVisible(false)} style={styles.closeButton}>
+            Close
+          </Button>
+        </Modal>
+      </Portal>
     </ThemedView>
   );
 }
@@ -82,5 +119,11 @@ const styles = StyleSheet.create({
   code: { marginBottom: 16 },
   remaining: { marginBottom: 8, fontWeight: 'bold' },
   button: { marginTop: 8 },
+  modal: {
+    backgroundColor: 'white',
+    padding: 24,
+    alignItems: 'center',
+  },
+  closeButton: { marginTop: 16 },
 });
 

--- a/app/sign-in.tsx
+++ b/app/sign-in.tsx
@@ -1,11 +1,16 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Alert, StyleSheet, View } from 'react-native';
 import { Button, Text, TextInput } from 'react-native-paper';
 import { useRouter } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
+import * as Google from 'expo-auth-session/providers/google';
+import { makeRedirectUri } from 'expo-auth-session';
 import { AuthFacade } from '@/facades/AuthFacade';
 import { useAuth } from '@/hooks/useAuth';
 import { ThemedView } from '@/components/ThemedView';
 import { useThemeColor } from '@/hooks/useThemeColor';
+
+WebBrowser.maybeCompleteAuthSession();
 
 const auth = new AuthFacade();
 
@@ -14,6 +19,22 @@ export default function SignIn() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const { signIn: setAuth } = useAuth();
+
+  const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
+    clientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID ?? '',
+    redirectUri: makeRedirectUri({ scheme: 'coffeesub' }),
+  });
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const { id_token } = response.params;
+      if (id_token) {
+        setAuth(id_token, '');
+        Alert.alert('Success', 'Signed in successfully');
+        router.replace('/(tabs)');
+      }
+    }
+  }, [response, router, setAuth]);
 
   const handleSignIn = async () => {
     try {
@@ -47,6 +68,14 @@ export default function SignIn() {
       />
       <Button mode="contained" onPress={handleSignIn} style={styles.button}>
         Sign In
+      </Button>
+      <Button
+        mode="outlined"
+        disabled={!request}
+        onPress={() => promptAsync({ useProxy: false })}
+        style={styles.button}
+      >
+        Sign In with Google
       </Button>
       <View style={styles.separator}>
         <Text style={[styles.separatorText, { color: textColor }]}>If you don&apos;t have an account</Text>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "react-native-paper": "^5.12.3",
-    "@react-native-async-storage/async-storage": "^1.23.0"
+    "@react-native-async-storage/async-storage": "^1.23.0",
+    "react-native-qrcode-svg": "^6.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/services/coffee/CoffeeItemService.ts
+++ b/services/coffee/CoffeeItemService.ts
@@ -38,4 +38,31 @@ export class CoffeeItemService {
     const json = await res.json();
     return json.data ?? json;
   }
+
+  async generateQrCode(
+    userId: number,
+    coffeeId: number,
+    token: string,
+  ): Promise<{ subscriptionId: number; coffeeCode: string; userId: number }> {
+    if (!API_URL) {
+      throw new Error('Missing API URL');
+    }
+
+    const res = await fetch(`${API_URL}/CoffeeItem/qrcode`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ userId, coffeeId }),
+    });
+
+    const json = await res.json().catch(() => null);
+    if (!res.ok) {
+      const message = json?.message || 'Failed to generate QR code';
+      throw new Error(message);
+    }
+
+    return json?.data ?? json;
+  }
 }


### PR DESCRIPTION
## Summary
- switch Google sign-in to use a custom `coffeesub` scheme instead of Expo proxy
- invoke OAuth flow without proxy when pressing the Google sign-in button
- generate a QR code after hitting **Use Ticket**, encoding subscription and coffee info for staff scanning
- send user and coffee IDs in the QR code request body with proper headers and error messaging

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@react-native-async-storage%2fasync-storage)
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: expo: not found)


------
https://chatgpt.com/codex/tasks/task_e_68abe7083e2883289877e6b116e6d3a3