### PR TITLE
Fix QR code generation request format

### DIFF
--- a/app/coffee/[id].tsx
+++ b/app/coffee/[id].tsx
@@ -47,12 +47,7 @@ export default function CoffeeDetail() {
     const svc = new CoffeeItemService();
     try {
       const res = await svc.generateQrCode(userId, Number(id), token);
-      const payload = JSON.stringify({
-        subscriptionId: res.subscriptionId,
-        coffeeCode: res.coffeeCode,
-        userId: res.userId,
-      });
-      setQrValue(payload);
+      setQrValue(JSON.stringify(res));
       setQrVisible(true);
     } catch (e) {
       console.error(e);

--- a/services/coffee/CoffeeItemService.ts
+++ b/services/coffee/CoffeeItemService.ts
@@ -43,19 +43,22 @@ export class CoffeeItemService {
     userId: number,
     coffeeId: number,
     token: string,
-  ): Promise<{ subscriptionId: number; coffeeCode: string; userId: number }> {
+  ): Promise<{
+    success: boolean;
+    message: string;
+    subscriptionId: number;
+    coffeeCode: string;
+    userId: number;
+  }> {
     if (!API_URL) {
       throw new Error('Missing API URL');
     }
 
+    // The QR-code endpoint expects the identifiers as query parameters on a GET
+    // request with an authorization header.
     const res = await fetch(
       `${API_URL}/CoffeeItem/qrcode?userId=${userId}&coffeeId=${coffeeId}`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      },
+      { headers: { Authorization: `Bearer ${token}` } },
     );
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- Request QR codes with bearer auth and query parameters
- Encode full API response into the generated QR code

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68ae19e70d588328bcc1c9e013c94e64