### PR TITLE
feat: toast errors for restricted API responses

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from '@/hooks/useAuth';
 import { ColorSchemeProvider, useColorScheme } from '@/hooks/useColorScheme';
 import { Provider as PaperProvider, MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
 import { Colors } from '@/constants/Colors';
+import { ToastContainer } from 'toastify-react-native';
 
 export default function RootLayout() {
   const [loaded] = useFonts({
@@ -93,6 +94,7 @@ function RootNavigation() {
             <Stack.Screen name="+not-found" />
           </Stack>
           <StatusBar style="auto" />
+          <ToastContainer />
         </ThemeProvider>
       </PaperProvider>
     </AuthProvider>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,7 +8,7 @@ import { AuthProvider } from '@/hooks/useAuth';
 import { ColorSchemeProvider, useColorScheme } from '@/hooks/useColorScheme';
 import { Provider as PaperProvider, MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
 import { Colors } from '@/constants/Colors';
-import { ToastContainer } from 'toastify-react-native';
+import ToastManager from 'toastify-react-native';
 
 export default function RootLayout() {
   const [loaded] = useFonts({
@@ -94,7 +94,7 @@ function RootNavigation() {
             <Stack.Screen name="+not-found" />
           </Stack>
           <StatusBar style="auto" />
-          <ToastContainer />
+          <ToastManager />
         </ThemeProvider>
       </PaperProvider>
     </AuthProvider>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "^13.14.0"
+    "react-native-webview": "^13.14.0",
+    "toastify-react-native": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,0 +1,24 @@
+import { Toast } from 'toastify-react-native';
+
+export async function fetchWithErrorHandling(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const res = await fetch(input, init);
+
+  if ([400, 401, 403].includes(res.status)) {
+    let message = 'An error occurred';
+    try {
+      const data = await res.json();
+      if (data?.message) {
+        message = data.message;
+      }
+    } catch (error) {
+      // ignore json parse errors
+    }
+    Toast.error(message);
+    throw new Error(message);
+  }
+
+  return res;
+}

--- a/services/auth/AuthService.ts
+++ b/services/auth/AuthService.ts
@@ -29,6 +29,8 @@ export interface User {
  * In a real application these methods would use `fetch` or another
  * networking library. Here we simply mock the behaviour.
  */
+import { fetchWithErrorHandling } from '../api';
+
 const API_URL = process.env.EXPO_PUBLIC_API_URL;
 
 export class AuthService {
@@ -37,7 +39,7 @@ export class AuthService {
       throw new Error('Missing API URL');
     }
 
-    const res = await fetch(`${API_URL}/Auth/login`, {
+    const res = await fetchWithErrorHandling(`${API_URL}/Auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password }),
@@ -65,7 +67,7 @@ export class AuthService {
       throw new Error('Missing API URL');
     }
 
-    const res = await fetch(`${API_URL}/Auth/google-login`, {
+    const res = await fetchWithErrorHandling(`${API_URL}/Auth/google-login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ idToken }),
@@ -88,7 +90,7 @@ export class AuthService {
       throw new Error('Missing API URL');
     }
 
-    const res = await fetch(`${API_URL}/Auth/current-logged-user`, {
+    const res = await fetchWithErrorHandling(`${API_URL}/Auth/current-logged-user`, {
       headers: { Authorization: `Bearer ${token}` },
     });
 

--- a/services/coffee/CategoryService.ts
+++ b/services/coffee/CategoryService.ts
@@ -4,6 +4,8 @@ export interface Category {
   description: string;
 }
 
+import { fetchWithErrorHandling } from '../api';
+
 const API_URL = process.env.EXPO_PUBLIC_API_URL;
 
 export class CategoryService {
@@ -12,7 +14,7 @@ export class CategoryService {
       throw new Error('Missing API URL');
     }
 
-    const res = await fetch(`${API_URL}/Category`);
+    const res = await fetchWithErrorHandling(`${API_URL}/Category`);
     if (!res.ok) {
       throw new Error('Failed to fetch categories');
     }

--- a/services/coffee/CoffeeItemService.ts
+++ b/services/coffee/CoffeeItemService.ts
@@ -8,6 +8,8 @@ export interface CoffeeItem {
   imageUrl?: string;
 }
 
+import { fetchWithErrorHandling } from '../api';
+
 const API_URL = process.env.EXPO_PUBLIC_API_URL;
 
 export class CoffeeItemService {
@@ -16,7 +18,7 @@ export class CoffeeItemService {
       throw new Error('Missing API URL');
     }
 
-    const res = await fetch(`${API_URL}/CoffeeItem`);
+    const res = await fetchWithErrorHandling(`${API_URL}/CoffeeItem`);
     if (!res.ok) {
       throw new Error('Failed to fetch coffee items');
     }
@@ -30,7 +32,7 @@ export class CoffeeItemService {
       throw new Error('Missing API URL');
     }
 
-    const res = await fetch(`${API_URL}/CoffeeItem/search`, {
+    const res = await fetchWithErrorHandling(`${API_URL}/CoffeeItem/search`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -52,7 +54,7 @@ export class CoffeeItemService {
       throw new Error('Missing API URL');
     }
 
-    const res = await fetch(`${API_URL}/CoffeeItem/${id}`);
+    const res = await fetchWithErrorHandling(`${API_URL}/CoffeeItem/${id}`);
     if (!res.ok) {
       throw new Error('Failed to fetch coffee item');
     }
@@ -69,7 +71,7 @@ export class CoffeeItemService {
     if (!API_URL) {
       throw new Error('Missing API URL');
     }
-    const res = await fetch(
+    const res = await fetchWithErrorHandling(
       `${API_URL}/CoffeeItem/qrcode?userId=${userId}&coffeeId=${coffeeId}`,
       {
         method: 'POST',

--- a/services/subscription/PlanService.ts
+++ b/services/subscription/PlanService.ts
@@ -1,4 +1,5 @@
 import { Plan } from '@/factories/PlanFactory';
+import { fetchWithErrorHandling } from '../api';
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL;
 
@@ -8,7 +9,7 @@ export class PlanService {
       throw new Error('Missing API URL');
     }
 
-    const res = await fetch(`${API_URL}/SubscriptionPlan`);
+    const res = await fetchWithErrorHandling(`${API_URL}/SubscriptionPlan`);
     if (!res.ok) {
       throw new Error('Failed to fetch subscription plans');
     }
@@ -22,7 +23,7 @@ export class PlanService {
       throw new Error('Missing API URL');
     }
 
-    const res = await fetch(`${API_URL}/SubscriptionPlan/${id}`);
+    const res = await fetchWithErrorHandling(`${API_URL}/SubscriptionPlan/${id}`);
     if (!res.ok) {
       throw new Error('Failed to fetch subscription plan');
     }
@@ -36,7 +37,7 @@ export class PlanService {
       throw new Error('Missing API URL');
     }
 
-    const res = await fetch(
+    const res = await fetchWithErrorHandling(
       `${API_URL}/Vnpay/CreatePaymentUrl?planId=${planId}&userId=${userId}`,
     );
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- add shared fetch helper that shows a toast on 400/401/403 API responses
- route service calls through new helper and wire up ToastContainer
- declare toastify-react-native dependency

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unable to resolve path to module 'toastify-react-native')

------
https://chatgpt.com/codex/tasks/task_e_68aefb6b5b48832881f882d85ea555ad