### PR TITLE
feat: implement user registration

### DIFF
--- a/app/sign-up.tsx
+++ b/app/sign-up.tsx
@@ -2,21 +2,40 @@ import React, { useState } from 'react';
 import { StyleSheet, Alert, View } from 'react-native';
 import { Button, Text, TextInput } from 'react-native-paper';
 import { useRouter } from 'expo-router';
-import { AuthFacade } from '@/facades/AuthFacade';
 import { ThemedView } from '@/components/ThemedView';
 import { useThemeColor } from '@/hooks/useThemeColor';
-
-const auth = new AuthFacade();
 
 export default function SignUp() {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [username, setUsername] = useState('');
+  const [fullName, setFullName] = useState('');
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleSignUp = async () => {
-    await auth.signUp({ email, password });
-    Alert.alert('Account created', 'Please sign in');
-    router.replace('/sign-in');
+    setLoading(true);
+    try {
+      const res = await fetch('https://coffe-subcription-3w.onrender.com/api/User', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password, username, fullName, phoneNumber }),
+      });
+      const json = await res.json();
+      if (res.ok && json?.success) {
+        Alert.alert('Account created', 'Please sign in');
+        router.replace('/sign-in');
+      } else {
+        const message = json?.message || 'Sign up failed';
+        Alert.alert('Sign up failed', message);
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      Alert.alert('Sign up failed', message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const textColor = useThemeColor({}, 'text');
@@ -26,6 +45,8 @@ export default function SignUp() {
         label="Email"
         value={email}
         onChangeText={setEmail}
+        autoCapitalize="none"
+        keyboardType="email-address"
         mode="outlined"
         style={styles.input}
       />
@@ -37,7 +58,36 @@ export default function SignUp() {
         mode="outlined"
         style={styles.input}
       />
-      <Button mode="contained" onPress={handleSignUp} style={styles.button}>
+      <TextInput
+        label="Username"
+        value={username}
+        onChangeText={setUsername}
+        autoCapitalize="none"
+        mode="outlined"
+        style={styles.input}
+      />
+      <TextInput
+        label="Full Name"
+        value={fullName}
+        onChangeText={setFullName}
+        mode="outlined"
+        style={styles.input}
+      />
+      <TextInput
+        label="Phone Number"
+        value={phoneNumber}
+        onChangeText={setPhoneNumber}
+        keyboardType="phone-pad"
+        mode="outlined"
+        style={styles.input}
+      />
+      <Button
+        mode="contained"
+        onPress={handleSignUp}
+        style={styles.button}
+        loading={loading}
+        disabled={loading}
+      >
         Sign Up
       </Button>
       <View style={styles.separator}>


### PR DESCRIPTION
## Summary
- add username, full name, and phone number fields to sign up
- implement POST request to coffe-subcription-3w API for user registration

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af1224d504832896f35f911ec5b9b9